### PR TITLE
Remove PREBUILD_ARCH and PREBUILD_PLATFORM

### DIFF
--- a/build
+++ b/build
@@ -208,8 +208,6 @@ $DOCKER run \
   --env NAME="${NAME}" \
   --env ARCH="${ARCH}" \
   --env PLATFORM="${PLATFORM}" \
-  --env PREBUILD_ARCH="${ARCH}" \
-  --env PREBUILD_PLATFORM="${PLATFORM}" \
   ${IMAGE_NAME}:${TARGET} \
   bash -e -o errexit -o pipefail -o noclobber -o nounset -c "
     cd /app; ./build-in-docker ${ARGUMENTS};


### PR DESCRIPTION
No need to set these env vars since they are set inside `prebuildify`, see

* https://github.com/mafintosh/prebuildify/blob/cde8800c6633e044d73c1eea7c84e962c64acbc1/index.js#L16-L17
* https://github.com/mafintosh/prebuildify/blob/cde8800c6633e044d73c1eea7c84e962c64acbc1/index.js#L30-L31