### PR TITLE
Use docker API v1.24

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,15 @@
 const packlist = require('npm-packlist')
 const tar = require('tar-fs')
 const dockerPull = require('@vweevers/docker-pull')
-const dockerRun = require('docker-run')
+const dockerRun = require('@thegecko/docker-run')
 const logger = require('log-update')
 const bytes = require('pretty-bytes')
 const browserify = require('browserify')
 const unixify = require('unixify')
 const once = require('once')
 const path = require('path')
+
+const DOCKER_VERSION = 'v1.24';
 
 module.exports = function (opts, callback) {
   if (typeof opts === 'function') {
@@ -44,7 +46,7 @@ module.exports = function (opts, callback) {
       }
     }
 
-    dockerPull(image)
+    dockerPull(image, { version: DOCKER_VERSION })
       .on('progress', progress)
       .on('error', callback)
       .on('end', end)
@@ -82,6 +84,7 @@ module.exports = function (opts, callback) {
     }
 
     const child = dockerRun(image, {
+      version: DOCKER_VERSION,
       entrypoint: 'node',
       argv: ['-'].concat(argv),
       volumes,

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const unixify = require('unixify')
 const once = require('once')
 const path = require('path')
 
-const DOCKER_VERSION = 'v1.24';
+const DOCKER_VERSION = 'v1.24'
 
 module.exports = function (opts, callback) {
   if (typeof opts === 'function') {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@vweevers/docker-pull": "^1.1.1",
+    "@thegecko/docker-run": "thegecko/docker-run#expose-version",
     "browserify": "^17.0.0",
-    "docker-run": "^3.1.0",
     "log-update": "^4.0.0",
     "minimist": "^1.2.0",
     "npm-packlist": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@vweevers/docker-pull": "^1.1.1",
-    "@thegecko/docker-run": "^3.0.0",
+    "@thegecko/docker-run": "^3.1.0",
     "browserify": "^17.0.0",
     "log-update": "^4.0.0",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@vweevers/docker-pull": "^1.1.1",
-    "@thegecko/docker-run": "thegecko/docker-run#expose-version",
+    "@thegecko/docker-run": "^3.0.0",
     "browserify": "^17.0.0",
     "log-update": "^4.0.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
With reference to #20 , this PR updates the underlying docker API to `v1.24`.

This fixes the docker issues and a successful build using this fix can be seen in:

- PR: https://github.com/node-usb/node-usb/pull/811.
- CI: https://github.com/node-usb/node-usb/actions/runs/10832374574

This change requires the `docker-run` package to be forked as seen in: https://github.com/thegecko/docker-run/tree/expose-version

@vweevers do you want this fork of `docker-run` to live alongside your [@vweevers/docker-pull](https://github.com/vweevers/docker-pull) fork or shall I publish it from `thegecko`?
