### PR TITLE
docker: set version to v1.24

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function (opts, callback) {
       }
     }
 
-    dockerPull(image)
+    dockerPull(image, { version: 'v1.24' })
       .on('progress', progress)
       .on('error', callback)
       .on('end', end)


### PR DESCRIPTION
example of working CI: https://github.com/cryptocoinjs/secp256k1-node/actions/runs/11382664061/job/31666651928

closes https://github.com/prebuild/prebuildify-cross/issues/20