### PR TITLE
Breaking: run `npm install` in guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Compile prebuilds in Docker, supporting Linux (including Debian 8, Ubuntu 14.04, RHEL 7, CentOS 7 and up), Alpine Linux, ARM Linux devices like the Raspberry Pi and mobile ARM devices like Android.**
 
-Runs [`prebuildify`](https://github.com/mafintosh/prebuildify) in preconfigured [`prebuild/docker-images`](https://github.com/prebuild/docker-images) containers to compile and name prebuilds for a certain platform. This means you don't have to worry about GCC flags, environment variables or system dependencies. In addition, `prebuildify-cross` copies only npm package files to Docker (following the rules of `.npmignore` and `files`) and mounts `node_modules` removing the need for a repeated `npm install`.
+Runs [`prebuildify`](https://github.com/mafintosh/prebuildify) in preconfigured [`prebuild/docker-images`](https://github.com/prebuild/docker-images) containers to compile and name prebuilds for a certain platform. This means you don't have to worry about GCC flags, environment variables or system dependencies.
 
 ## Install
 
@@ -32,12 +32,6 @@ To use `latest` images (not recommended) an image tag must be specified explicit
 
 ```
 prebuildify-cross -i linux-armv7:latest -t ..
-```
-
-When working in a monorepo, where `./node_modules` does not contain the dependencies that `prebuildify-cross` relies upon, a custom path can be provided with `--modules`. It can be an absolute path or relative to the current working directory. For example:
-
-```sh
-prebuildify-cross --modules ../../node_modules -i linux-armv7:latest -t 20.0.0 --strip
 ```
 
 ## Images

--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,7 @@
 const argv = process.argv.slice(2)
 
 const opts = require('minimist')(argv, {
-  string: ['image', 'cwd', 'modules'],
+  string: ['image', 'cwd'],
   alias: { image: 'i' }
 })
 

--- a/guest.js
+++ b/guest.js
@@ -19,14 +19,16 @@ for (const file of files) {
   fs.chmodSync(b, 0o644)
 }
 
-// Use node_modules of host to avoid a second install step
-fs.symlinkSync('/input/node_modules', path.join(cwd, 'node_modules'))
-
 const stdio = ['ignore', 2, 2]
-const res = cp.spawnSync('npx', ['--no-install', 'prebuildify', ...argv], { cwd, stdio })
+const installResult = cp.spawnSync('npm', ['install', '--ignore-scripts'], { cwd, stdio })
 
-if (res.status) process.exit(res.status)
-if (res.error) throw res.error
+if (installResult.status) process.exit(installResult.status)
+if (installResult.error) throw installResult.error
+
+const buildResult = cp.spawnSync('npx', ['--no-install', 'prebuildify', ...argv], { cwd, stdio })
+
+if (buildResult.status) process.exit(buildResult.status)
+if (buildResult.error) throw buildResult.error
 
 // Write tarball to stdout. With this approach we don't need
 // a writable volume and can avoid messing with permissions.

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = function (opts, callback) {
 
   const images = [].concat(opts.image || [])
   const cwd = path.resolve(opts.cwd || '.')
-  const modules = opts.modules ? path.resolve(cwd, opts.modules) : null
 
   const files = JSON.stringify(packageFiles(cwd))
   const prebuilds = path.join(cwd, 'prebuilds')
@@ -77,10 +76,6 @@ module.exports = function (opts, callback) {
     const volumes = {
       // Should but can't use :ro (mafintosh/docker-run#12)
       [cygwin(cwd)]: '/input'
-    }
-
-    if (modules) {
-      volumes[modules] = '/input/node_modules'
     }
 
     const child = dockerRun(image, {
@@ -137,9 +132,6 @@ function prebuildifyArgv (argv, image) {
       argv.splice(i--, 2)
     }
     if (/^(--cwd)$/.test(argv[i]) && argv[i + 1][0] !== '-') {
-      argv.splice(i--, 2)
-    }
-    if (/^(--modules)$/.test(argv[i]) && argv[i + 1][0] !== '-') {
       argv.splice(i--, 2)
     }
   }


### PR DESCRIPTION
Avoiding a repeated install reduced build time but it breaks use of node-addon-api: https://github.com/prebuild/prebuildify-cross/issues/23

This is a breaking change because it removes the `--modules` option from https://github.com/prebuild/prebuildify-cross/pull/19 which is no longer necessary (cc @kirrg001).